### PR TITLE
add option to configure which sql strategy should be used to reserve

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", [">= 3.0", "< 5.0"]
   spec.add_dependency "delayed_job",  [">= 3.0", "< 4.1"]
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
-  spec.description    = "ActiveRecord backend for Delayed::Job, originally authored by Tobias Lütke"
+  spec.description    = "ActiveRecord backend for Delayed::Job, originally authored by Tobias Lutke"
   spec.email          = ["bryckbost@gmail.com", "matt@griffinonline.org", "sferik@gmail.com"]
   spec.files          = %w(CONTRIBUTING.md LICENSE.md README.md delayed_job_active_record.gemspec) + Dir["lib/**/*.rb"]
   spec.homepage       = "http://github.com/collectiveidea/delayed_job_active_record"


### PR DESCRIPTION
Merge in https://github.com/collectiveidea/delayed_job_active_record/pull/111 to allow use of the older, less deadlock-y sql scope.
